### PR TITLE
DNM: test impact of bazel's --experimental_remote_download_outputs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -121,10 +121,10 @@ build:remote --strategy=Closure=remote,sandboxed,local
 build:remote --strategy=Genrule=remote,sandboxed,local
 build:remote --remote_timeout=3600
 build:remote --auth_enabled=true
-build:remote --experimental_inmemory_jdeps_files
-build:remote --experimental_inmemory_dotd_files
-build:remote --experimental_remote_download_outputs=toplevel
-test:remote --experimental_remote_download_outputs=minimal
+#build:remote --experimental_inmemory_jdeps_files
+#build:remote --experimental_inmemory_dotd_files
+#build:remote --experimental_remote_download_outputs=toplevel
+#test:remote --experimental_remote_download_outputs=minimal
 
 build:remote-clang --config=remote
 build:remote-clang --config=rbe-toolchain-clang


### PR DESCRIPTION
I am working on Bazel/RBE and noticed that you are using the new "Builds without the Bytes" feature. This PR is just to test it's impact on performance. This should not be merged. Hope that's ok.